### PR TITLE
correct wrong timestamp strings in the list

### DIFF
--- a/index.md
+++ b/index.md
@@ -11,8 +11,8 @@ layout: default
 ## RISC-V双周简报
 
 国内的RISC-V爱好者利用Github协作的方式，以双周简报的方式为大家带来最新的RISC-V相关咨询，同时在微信公众号和CNRV站点上发布。内容覆盖RISC-V邮件列表、行业新闻、项目进展以及各类点评。也欢迎大家关注CNRV公众号获取最新信息。
-- **第0x0f弹(2017-01-18): [Google开源RISC-V CPU](bi-week-rpts/2018-01-18) [\[繁体\]](bi-week-rpts/2018-01-18.tc)**
-- 第0x0e弹(2017-01-04): [Intel漏洞是非多！](bi-week-rpts/2018-01-04) [\[繁体\]](bi-week-rpts/2018-01-04.tc)
+- **第0x0f弹(2018-01-18): [Google开源RISC-V CPU](bi-week-rpts/2018-01-18) [\[繁体\]](bi-week-rpts/2018-01-18.tc)**
+- 第0x0e弹(2018-01-04): [Intel漏洞是非多！](bi-week-rpts/2018-01-04) [\[繁体\]](bi-week-rpts/2018-01-04.tc)
 - 第0x0d弹(2017-12-21): [Esperanto Technologies会成功么？](bi-week-rpts/2017-12-21) [\[繁体\]](bi-week-rpts/2017-12-21.tc)
 - 第0x0c弹(2017-12-07): [Workshop上干活多多](bi-week-rpts/2017-12-07) [\[繁体\]](bi-week-rpts/2017-12-07.tc)
 - 第0x0b弹(2017-11-23): [3家RISC-V相关的公司上榜“EE Times Silicon 60: Startups to Watch”](bi-week-rpts/2017-11-23) [\[繁体\]](bi-week-rpts/2017-11-23.tc)


### PR DESCRIPTION
the top two report entries are for 2018 not 2017